### PR TITLE
Implement JWT refresh token mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ The application provides a RESTful API with the following main endpoints:
 
 ### Authentication
 - `POST /auth/register`: Register a new user
-- `POST /auth/login`: Authenticate and get JWT token
+- `POST /auth/login`: Authenticate and get JWT access and refresh tokens
+- `POST /auth/refresh-token`: Get a new JWT access token with a valid refresh token
+- `POST /auth/logout`: Revoke a refresh token
 
 ### Book Management
 - `GET /books`: Get all books with pagination
@@ -218,7 +220,16 @@ All protected endpoints require a JWT token passed in the Authorization header:
 Authorization: Bearer <token>
 ```
 
-The token is obtained by logging in via the `/auth/login` endpoint.
+The access token is obtained by logging in via the `/auth/login` endpoint. The login response includes `token`, `accessToken`, `refreshToken`, `username`, and `role`; `token` is kept as an alias of `accessToken` for compatibility.
+
+When an access token expires, call `/auth/refresh-token` with the refresh token:
+```json
+{
+  "refreshToken": "refresh-token-value"
+}
+```
+
+The refresh endpoint returns a new access token and the same refresh token. To log out, call `/auth/logout` with the same request body. A revoked refresh token cannot be used again. Refresh tokens are stored server-side and are not valid as `Authorization: Bearer` tokens for protected APIs.
 
 ### Data Initialization
 
@@ -243,7 +254,6 @@ A Postman collection is included in the repository (`library_management_system_p
 - Implement caching for frequently accessed data
 - Add support for digital books and e-lending
 - CSRF protection for all forms
-- Refresh token mechanism for JWT
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<lombok.version>1.18.42</lombok.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -42,6 +43,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -158,7 +160,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.36</version>
+							<version>${lombok.version}</version>
 						</path>
 						<path>
 							<groupId>org.projectlombok</groupId>
@@ -179,6 +181,14 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-Dnet.bytebuddy.experimental=true</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/common/exception/auth/InvalidRefreshTokenException.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/common/exception/auth/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.ilhanozkan.libraryManagementSystem.common.exception.auth;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+  public InvalidRefreshTokenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/controller/AuthController.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.ilhanozkan.libraryManagementSystem.controller;
 
+import com.ilhanozkan.libraryManagementSystem.common.exception.auth.InvalidRefreshTokenException;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.LoginRequestDTO;
+import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RefreshTokenRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RegisterRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.response.auth.LoginResponseDTO;
 import com.ilhanozkan.libraryManagementSystem.service.AuthService;
@@ -79,6 +81,8 @@ public class AuthController {
         // Return in format expected by tests
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("token", loginResponseDTO.getToken());
+        responseMap.put("accessToken", loginResponseDTO.getAccessToken());
+        responseMap.put("refreshToken", loginResponseDTO.getRefreshToken());
         responseMap.put("username", loginResponseDTO.getUsername());
         responseMap.put("role", loginResponseDTO.getRole());
         
@@ -89,6 +93,52 @@ public class AuthController {
       }
     } catch (RuntimeException e) {
       log.error("Login failed for username {}: {}", requestDTO.getUsername(), e.getMessage());
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+  }
+
+  @Operation(summary = "Refresh access token", description = "Generates a new JWT access token using a valid refresh token")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Successfully refreshed access token"),
+      @ApiResponse(responseCode = "401", description = "Invalid, expired, or revoked refresh token")
+  })
+  @PostMapping("/refresh-token")
+  public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequestDTO requestDTO) {
+    try {
+      ResponseEntity<?> serviceResponse = authService.refreshToken(requestDTO);
+      LoginResponseDTO loginResponseDTO = (LoginResponseDTO) serviceResponse.getBody();
+
+      Map<String, Object> responseMap = new HashMap<>();
+      responseMap.put("token", loginResponseDTO.getToken());
+      responseMap.put("accessToken", loginResponseDTO.getAccessToken());
+      responseMap.put("refreshToken", loginResponseDTO.getRefreshToken());
+      responseMap.put("username", loginResponseDTO.getUsername());
+      responseMap.put("role", loginResponseDTO.getRole());
+
+      return ResponseEntity.ok(responseMap);
+    } catch (InvalidRefreshTokenException e) {
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("success", false);
+      errorResponse.put("message", e.getMessage());
+      errorResponse.put("data", null);
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+  }
+
+  @Operation(summary = "Logout user", description = "Revokes the supplied refresh token")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Successfully logged out"),
+      @ApiResponse(responseCode = "401", description = "Invalid refresh token")
+  })
+  @PostMapping("/logout")
+  public ResponseEntity<?> logout(@RequestBody RefreshTokenRequestDTO requestDTO) {
+    try {
+      return authService.logout(requestDTO);
+    } catch (InvalidRefreshTokenException e) {
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("success", false);
+      errorResponse.put("message", e.getMessage());
+      errorResponse.put("data", null);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
   }

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/model/dto/request/auth/RefreshTokenRequestDTO.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/model/dto/request/auth/RefreshTokenRequestDTO.java
@@ -1,0 +1,16 @@
+package com.ilhanozkan.libraryManagementSystem.model.dto.request.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenRequestDTO {
+  @NotBlank(message = "Refresh token is required")
+  private String refreshToken;
+}

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/model/dto/response/auth/LoginResponseDTO.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/model/dto/response/auth/LoginResponseDTO.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginResponseDTO {
   private String token;
+  private String accessToken;
+  private String refreshToken;
   private String username;
   private UserRole role;
 }

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/model/entity/RefreshToken.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/model/entity/RefreshToken.java
@@ -1,0 +1,58 @@
+package com.ilhanozkan.libraryManagementSystem.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshToken {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(nullable = false, unique = true)
+  private String token;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private User user;
+
+  @Column(nullable = false)
+  private Instant expiryDate;
+
+  @Column(nullable = false)
+  private boolean revoked;
+
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @PrePersist
+  public void onCreate() {
+    if (this.id == null)
+      this.id = UUID.randomUUID();
+
+    if (this.createdAt == null)
+      this.createdAt = Instant.now();
+  }
+}

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/repository/RefreshTokenRepository.java
@@ -1,0 +1,21 @@
+package com.ilhanozkan.libraryManagementSystem.repository;
+
+import com.ilhanozkan.libraryManagementSystem.model.entity.RefreshToken;
+import com.ilhanozkan.libraryManagementSystem.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+  Optional<RefreshToken> findByToken(String token);
+
+  List<RefreshToken> findByUser(User user);
+
+  @Modifying
+  @Query("update RefreshToken r set r.revoked = true where r.user = :user and r.revoked = false")
+  void revokeAllByUser(User user);
+}

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/security/WebSecurityConfig.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/security/WebSecurityConfig.java
@@ -47,7 +47,7 @@ public class WebSecurityConfig {
             .authorizeHttpRequests(
                 auth -> {
                     // Public endpoints
-                    auth.requestMatchers("/auth/**").permitAll()
+                    auth.requestMatchers("/auth/login", "/auth/register", "/auth/refresh-token", "/auth/logout").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll();
                     
                     if (isTestProfile) {

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/service/AuthService.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.ilhanozkan.libraryManagementSystem.service;
 
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.LoginRequestDTO;
+import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RefreshTokenRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RegisterRequestDTO;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.ResponseEntity;
@@ -8,4 +9,6 @@ import org.springframework.http.ResponseEntity;
 public interface AuthService {
   public String register(RegisterRequestDTO registerRequestDTO) throws BadRequestException;
   public ResponseEntity<?> login(LoginRequestDTO loginRequestDTO);
+  public ResponseEntity<?> refreshToken(RefreshTokenRequestDTO refreshTokenRequestDTO);
+  public ResponseEntity<?> logout(RefreshTokenRequestDTO refreshTokenRequestDTO);
 }

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/service/RefreshTokenService.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/service/RefreshTokenService.java
@@ -1,0 +1,14 @@
+package com.ilhanozkan.libraryManagementSystem.service;
+
+import com.ilhanozkan.libraryManagementSystem.model.entity.RefreshToken;
+import com.ilhanozkan.libraryManagementSystem.model.entity.User;
+
+import java.util.Optional;
+
+public interface RefreshTokenService {
+  RefreshToken createRefreshToken(User user);
+  Optional<RefreshToken> findByToken(String token);
+  RefreshToken validateRefreshToken(String token);
+  void revokeRefreshToken(String token);
+  void revokeAllByUser(User user);
+}

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/service/impl/AuthServiceImpl.java
@@ -1,13 +1,17 @@
 package com.ilhanozkan.libraryManagementSystem.service.impl;
 
+import com.ilhanozkan.libraryManagementSystem.common.apiResponse.ApiResponseModel;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.LoginRequestDTO;
+import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RefreshTokenRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RegisterRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.response.auth.LoginResponseDTO;
+import com.ilhanozkan.libraryManagementSystem.model.entity.RefreshToken;
 import com.ilhanozkan.libraryManagementSystem.model.entity.User;
 import com.ilhanozkan.libraryManagementSystem.model.enums.UserRole;
 import com.ilhanozkan.libraryManagementSystem.repository.UserRepository;
 import com.ilhanozkan.libraryManagementSystem.security.JwtService;
 import com.ilhanozkan.libraryManagementSystem.service.AuthService;
+import com.ilhanozkan.libraryManagementSystem.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
@@ -28,6 +32,7 @@ public class AuthServiceImpl implements AuthService {
   private final UserRepository userRepository;
   private final AuthenticationManager authenticationManager;
   private final JwtService jwtService;
+  private final RefreshTokenService refreshTokenService;
 
   @Override
   @Transactional
@@ -81,6 +86,8 @@ public class AuthServiceImpl implements AuthService {
 
       UserDetails userDetails = (UserDetails) authentication.getPrincipal();
       String token = jwtService.generateToken(userDetails.getUsername());
+      User user = userRepository.findByUsername(userDetails.getUsername());
+      RefreshToken refreshToken = refreshTokenService.createRefreshToken(user);
       log.info("User '{}' authenticated successfully, token generated", userDetails.getUsername());
 
       String role = userDetails.getAuthorities().stream()
@@ -105,6 +112,8 @@ public class AuthServiceImpl implements AuthService {
 
       LoginResponseDTO loginResponseDTO = LoginResponseDTO.builder()
           .token(token)
+          .accessToken(token)
+          .refreshToken(refreshToken.getToken())
           .username(userDetails.getUsername())
           .role(userRole)
           .build();
@@ -114,5 +123,28 @@ public class AuthServiceImpl implements AuthService {
       log.error("Authentication failed for username: {}", loginRequestDTO.getUsername(), e);
       return ResponseEntity.status(401).body("Invalid username or password");
     }
+  }
+
+  @Override
+  public ResponseEntity<?> refreshToken(RefreshTokenRequestDTO refreshTokenRequestDTO) {
+    RefreshToken refreshToken = refreshTokenService.validateRefreshToken(refreshTokenRequestDTO.getRefreshToken());
+    User user = refreshToken.getUser();
+    String accessToken = jwtService.generateToken(user.getUsername());
+
+    LoginResponseDTO loginResponseDTO = LoginResponseDTO.builder()
+        .token(accessToken)
+        .accessToken(accessToken)
+        .refreshToken(refreshToken.getToken())
+        .username(user.getUsername())
+        .role(user.getRole())
+        .build();
+
+    return ResponseEntity.ok(loginResponseDTO);
+  }
+
+  @Override
+  public ResponseEntity<?> logout(RefreshTokenRequestDTO refreshTokenRequestDTO) {
+    refreshTokenService.revokeRefreshToken(refreshTokenRequestDTO.getRefreshToken());
+    return ResponseEntity.ok(ApiResponseModel.success("Logged out successfully", null));
   }
 }

--- a/src/main/java/com/ilhanozkan/libraryManagementSystem/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/ilhanozkan/libraryManagementSystem/service/impl/RefreshTokenServiceImpl.java
@@ -1,0 +1,82 @@
+package com.ilhanozkan.libraryManagementSystem.service.impl;
+
+import com.ilhanozkan.libraryManagementSystem.common.exception.auth.InvalidRefreshTokenException;
+import com.ilhanozkan.libraryManagementSystem.model.entity.RefreshToken;
+import com.ilhanozkan.libraryManagementSystem.model.entity.User;
+import com.ilhanozkan.libraryManagementSystem.repository.RefreshTokenRepository;
+import com.ilhanozkan.libraryManagementSystem.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Value("${jwt.refresh-expiration}")
+  private long refreshTokenExpiration;
+
+  @Override
+  @Transactional
+  public RefreshToken createRefreshToken(User user) {
+    RefreshToken refreshToken = RefreshToken.builder()
+        .token(UUID.randomUUID().toString())
+        .user(user)
+        .expiryDate(Instant.now().plusMillis(refreshTokenExpiration))
+        .revoked(false)
+        .build();
+
+    RefreshToken savedToken = refreshTokenRepository.save(refreshToken);
+    log.debug("Refresh token created for user: {}", user.getUsername());
+    return savedToken;
+  }
+
+  @Override
+  public Optional<RefreshToken> findByToken(String token) {
+    return refreshTokenRepository.findByToken(token);
+  }
+
+  @Override
+  @Transactional
+  public RefreshToken validateRefreshToken(String token) {
+    RefreshToken refreshToken = findByToken(token)
+        .orElseThrow(() -> new InvalidRefreshTokenException("Invalid refresh token"));
+
+    if (refreshToken.isRevoked()) {
+      throw new InvalidRefreshTokenException("Refresh token has been revoked");
+    }
+
+    if (refreshToken.getExpiryDate().isBefore(Instant.now())) {
+      refreshToken.setRevoked(true);
+      refreshTokenRepository.save(refreshToken);
+      throw new InvalidRefreshTokenException("Refresh token has expired");
+    }
+
+    return refreshToken;
+  }
+
+  @Override
+  @Transactional
+  public void revokeRefreshToken(String token) {
+    RefreshToken refreshToken = findByToken(token)
+        .orElseThrow(() -> new InvalidRefreshTokenException("Invalid refresh token"));
+
+    refreshToken.setRevoked(true);
+    refreshTokenRepository.save(refreshToken);
+    log.debug("Refresh token revoked for user: {}", refreshToken.getUser().getUsername());
+  }
+
+  @Override
+  @Transactional
+  public void revokeAllByUser(User user) {
+    refreshTokenRepository.revokeAllByUser(user);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,3 +43,4 @@ logging:
 jwt:
   secret: OyF0epYib3QdHHfUc/PG6wjnkGuWZVVnDWcmxbL5tccsJ/xglg6fMWpr222kTWsc
   expiration: 86400000  # 24 hours in milliseconds
+  refresh-expiration: 604800000  # 7 days in milliseconds

--- a/src/test/java/com/ilhanozkan/libraryManagementSystem/LibraryManagementSystemApplicationTests.java
+++ b/src/test/java/com/ilhanozkan/libraryManagementSystem/LibraryManagementSystemApplicationTests.java
@@ -2,8 +2,10 @@ package com.ilhanozkan.libraryManagementSystem;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class LibraryManagementSystemApplicationTests {
 
 	@Test

--- a/src/test/java/com/ilhanozkan/libraryManagementSystem/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/ilhanozkan/libraryManagementSystem/controller/AuthControllerIntegrationTest.java
@@ -2,10 +2,12 @@ package com.ilhanozkan.libraryManagementSystem.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.LoginRequestDTO;
+import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RefreshTokenRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RegisterRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.entity.User;
 import com.ilhanozkan.libraryManagementSystem.model.enums.UserRole;
 import com.ilhanozkan.libraryManagementSystem.model.enums.UserStatus;
+import com.ilhanozkan.libraryManagementSystem.repository.RefreshTokenRepository;
 import com.ilhanozkan.libraryManagementSystem.repository.UserRepository;
 import com.ilhanozkan.libraryManagementSystem.repository.BorrowingRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,9 +48,13 @@ public class AuthControllerIntegrationTest {
     @Autowired
     private BorrowingRepository borrowingRepository;
 
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
     @BeforeEach
     void setUp() {
         // Clean up repository
+        refreshTokenRepository.deleteAll();
         borrowingRepository.deleteAll();
         userRepository.deleteAll();
 
@@ -145,7 +151,96 @@ public class AuthControllerIntegrationTest {
         // Then
         response.andExpect(status().isOk())
                 .andExpect(jsonPath("$.token", notNullValue()))
+                .andExpect(jsonPath("$.accessToken", notNullValue()))
+                .andExpect(jsonPath("$.refreshToken", notNullValue()))
                 .andExpect(jsonPath("$.username", is("existinguser")))
+                .andDo(print());
+    }
+
+    @Test
+    public void shouldRefreshAccessTokenWithValidRefreshToken() throws Exception {
+        // Given
+        LoginRequestDTO loginRequestDTO = new LoginRequestDTO();
+        loginRequestDTO.setUsername("existinguser");
+        loginRequestDTO.setPassword("password");
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequestDTO)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String refreshToken = objectMapper.readTree(loginResponse).get("refreshToken").asText();
+        RefreshTokenRequestDTO refreshTokenRequestDTO = RefreshTokenRequestDTO.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        // When
+        ResultActions response = mockMvc.perform(post("/auth/refresh-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDTO)));
+
+        // Then
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath("$.token", notNullValue()))
+                .andExpect(jsonPath("$.accessToken", notNullValue()))
+                .andExpect(jsonPath("$.refreshToken", is(refreshToken)))
+                .andExpect(jsonPath("$.username", is("existinguser")))
+                .andDo(print());
+    }
+
+    @Test
+    public void shouldRejectInvalidRefreshToken() throws Exception {
+        // Given
+        RefreshTokenRequestDTO refreshTokenRequestDTO = RefreshTokenRequestDTO.builder()
+                .refreshToken("invalid-refresh-token")
+                .build();
+
+        // When
+        ResultActions response = mockMvc.perform(post("/auth/refresh-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDTO)));
+
+        // Then
+        response.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andDo(print());
+    }
+
+    @Test
+    public void shouldRevokeRefreshTokenOnLogout() throws Exception {
+        // Given
+        LoginRequestDTO loginRequestDTO = new LoginRequestDTO();
+        loginRequestDTO.setUsername("existinguser");
+        loginRequestDTO.setPassword("password");
+
+        String loginResponse = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequestDTO)))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String refreshToken = objectMapper.readTree(loginResponse).get("refreshToken").asText();
+        RefreshTokenRequestDTO refreshTokenRequestDTO = RefreshTokenRequestDTO.builder()
+                .refreshToken(refreshToken)
+                .build();
+
+        // When
+        mockMvc.perform(post("/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andDo(print());
+
+        // Then
+        mockMvc.perform(post("/auth/refresh-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshTokenRequestDTO)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success", is(false)))
                 .andDo(print());
     }
 

--- a/src/test/java/com/ilhanozkan/libraryManagementSystem/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/ilhanozkan/libraryManagementSystem/service/impl/AuthServiceImplTest.java
@@ -1,12 +1,15 @@
 package com.ilhanozkan.libraryManagementSystem.service.impl;
 
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.LoginRequestDTO;
+import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RefreshTokenRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.request.auth.RegisterRequestDTO;
 import com.ilhanozkan.libraryManagementSystem.model.dto.response.auth.LoginResponseDTO;
+import com.ilhanozkan.libraryManagementSystem.model.entity.RefreshToken;
 import com.ilhanozkan.libraryManagementSystem.model.entity.User;
 import com.ilhanozkan.libraryManagementSystem.model.enums.UserRole;
 import com.ilhanozkan.libraryManagementSystem.repository.UserRepository;
 import com.ilhanozkan.libraryManagementSystem.security.JwtService;
+import com.ilhanozkan.libraryManagementSystem.service.RefreshTokenService;
 import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +51,9 @@ class AuthServiceImplTest {
 
     @Mock
     private JwtService jwtService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @Mock
     private Authentication authentication;
@@ -199,6 +205,11 @@ class AuthServiceImplTest {
         given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).willReturn(authentication);
         given(authentication.getPrincipal()).willReturn(userDetails);
         given(jwtService.generateToken("testuser")).willReturn("jwt-token");
+        given(userRepository.findByUsername("testuser")).willReturn(user);
+        given(refreshTokenService.createRefreshToken(user)).willReturn(RefreshToken.builder()
+                .token("refresh-token")
+                .user(user)
+                .build());
 
         // Act
         ResponseEntity<?> response = authService.login(loginRequestDTO);
@@ -209,11 +220,62 @@ class AuthServiceImplTest {
         
         LoginResponseDTO responseDTO = (LoginResponseDTO) response.getBody();
         assertThat(responseDTO.getToken()).isEqualTo("jwt-token");
+        assertThat(responseDTO.getAccessToken()).isEqualTo("jwt-token");
+        assertThat(responseDTO.getRefreshToken()).isEqualTo("refresh-token");
         assertThat(responseDTO.getUsername()).isEqualTo("testuser");
         assertThat(responseDTO.getRole()).isEqualTo(UserRole.PATRON);
         
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(jwtService).generateToken("testuser");
+        verify(refreshTokenService).createRefreshToken(user);
+    }
+
+    @Test
+    void shouldRefreshAccessTokenSuccessfully() {
+        // Arrange
+        RefreshTokenRequestDTO requestDTO = RefreshTokenRequestDTO.builder()
+                .refreshToken("refresh-token")
+                .build();
+        user.setUsername("testuser");
+        user.setRole(UserRole.PATRON);
+
+        given(refreshTokenService.validateRefreshToken("refresh-token")).willReturn(RefreshToken.builder()
+                .token("refresh-token")
+                .user(user)
+                .build());
+        given(jwtService.generateToken("testuser")).willReturn("new-jwt-token");
+
+        // Act
+        ResponseEntity<?> response = authService.refreshToken(requestDTO);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(LoginResponseDTO.class);
+
+        LoginResponseDTO responseDTO = (LoginResponseDTO) response.getBody();
+        assertThat(responseDTO.getToken()).isEqualTo("new-jwt-token");
+        assertThat(responseDTO.getAccessToken()).isEqualTo("new-jwt-token");
+        assertThat(responseDTO.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(responseDTO.getUsername()).isEqualTo("testuser");
+        assertThat(responseDTO.getRole()).isEqualTo(UserRole.PATRON);
+
+        verify(refreshTokenService).validateRefreshToken("refresh-token");
+        verify(jwtService).generateToken("testuser");
+    }
+
+    @Test
+    void shouldRevokeRefreshTokenOnLogout() {
+        // Arrange
+        RefreshTokenRequestDTO requestDTO = RefreshTokenRequestDTO.builder()
+                .refreshToken("refresh-token")
+                .build();
+
+        // Act
+        ResponseEntity<?> response = authService.logout(requestDTO);
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(refreshTokenService).revokeRefreshToken("refresh-token");
     }
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,3 +20,4 @@ spring:
 jwt:
   secret: testsecretfortestingtestsecretfortestingtestsecretfortesting
   expiration: 86400000 
+  refresh-expiration: 604800000


### PR DESCRIPTION
This pull request implements the Seamless Authentication Flow enhancement by adding JWT refresh token support.

Changes include:
- Added refresh token entity, repository, service, and DTO.
- Updated login response to return access token and refresh token.
- Added refresh-token endpoint to generate a new access token.
- Added logout endpoint to revoke refresh token.
- Updated security configuration and tests.
- Updated README/application configuration where needed.

Tested:
- Login returns accessToken and refreshToken.
- Valid refresh token returns new accessToken.
- Invalid refresh token is rejected.
- Logout revokes refresh token.
- Revoked refresh token cannot be reused.
- Protected API works with Bearer accessToken.